### PR TITLE
Reduce wait time on failure etcd watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#34] Reduce the wait time on failures while watching the etcd from 5 minutes to 10 seconds.
 
 ## [v0.12.1] - 2023-08-23
 ### Changed

--- a/registry/resilentetcdclient.go
+++ b/registry/resilentetcdclient.go
@@ -282,11 +282,11 @@ func (etcd *resilentEtcdClient) doWatch(ctx context.Context, watcher client.Watc
 	resp, err := watcher.Next(ctx)
 	if err != nil {
 		if strings.Contains(err.Error(), "etcd cluster is unavailable or misconfigured") {
-			core.GetLogger().Infof("Cannot reach etcd cluster. Try again in 300 seconds. Error: %v", err)
+			core.GetLogger().Infof("Cannot reach etcd cluster. Try again in 10 seconds. Error: %v", err)
 			etcd.indexMutex.Lock()
 			defer etcd.indexMutex.Unlock()
 			etcd.recentIndex = 0
-			time.Sleep(time.Minute * 5)
+			time.Sleep(time.Second * 10)
 			return
 		} else {
 			core.GetLogger().Infof("Could not get event. Try again in 30 seconds. Error: %v", err)


### PR DESCRIPTION
Reduce wait time on failure etcd watches from 5 minutes to 10 seconds.

If multiple watches are active (e.g. 5) and all will fail (e.g. etcd is not up) the wait time can be up to 25 minutes for the last watch because the mutex.lock function blocks until this previous wait is over.

Resolves #34 