### PR TITLE
Add marketing dogu struct

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ void make(String makeArgs) {
 }
 
 void withBuildDependencies(Closure closure) {
-    def etcdImage = docker.image('quay.io/coreos/etcd:v3.2.5')
+    def etcdImage = docker.image('quay.io/coreos/etcd:v3.2.32')
     def etcdContainerName = "${JOB_BASE_NAME}-${BUILD_NUMBER}".replaceAll("\\/|%2[fF]", "-")
     withDockerNetwork { buildnetwork ->
         etcdImage.withRun("--network ${buildnetwork} --name ${etcdContainerName}", 'etcd --listen-client-urls http://0.0.0.0:4001 --advertise-client-urls http://0.0.0.0:4001')

--- a/core/dogu_v2.go
+++ b/core/dogu_v2.go
@@ -606,17 +606,17 @@ type Dogu struct {
 	// Usages:
 	// In the setup of the ecosystem the display name of the dogu is used to select it for installation.
 	//
-	// the display name is used in the warp menu to let the user navigate to the web ui of the dogu.
+	// The display name is used in the warp menu to let the user navigate to the web ui of the dogu.
 	//
 	// Another usage is the textual output of tools like the cesapp or the k8s-dogu-operator where the name is used
 	// in commands like list upgradeable dogus.
 	//
-	// The description may consist of:
+	// The display name may consist of:
 	//   - lower and upper case latin characters where the first is upper case
 	//   - any special characters
 	//   - ciphers 0-9
 	//
-	// Description is encouraged to consist of less than 30 characters because it is displayed in the Cloudogu EcoSystem
+	// DisplayName is encouraged to consist of less than 30 characters because it is displayed in the Cloudogu EcoSystem
 	// warp menu.
 	//
 	// Examples:

--- a/core/marketing_dogu.go
+++ b/core/marketing_dogu.go
@@ -12,11 +12,11 @@ package core
 //		"DisplayName": "My New Dogu",
 //		"Provider": [
 //			{
-//				"Slug": "provider",
-//				"Name": "Provider",
+//				"Slug": "cloudogu",
+//				"Name": "Cloudogu GmbH",
 //				"Logo": {
 //					"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
-//					"Title": "Provider logo"
+//					"Title": "Cloudogu GmbH logo"
 //				}
 //			}
 //		],
@@ -48,7 +48,9 @@ type MarketingDogu struct {
 	//   - 34393ef9-a96d-4d1d-823e-0c17b10b762d
 	//
 	ID string
-	// Deprecated indicates if the dogu is deprecated.
+	// Deprecated indicates that this dogu is not recommended for new installations.
+	// There will be no further development and updates.
+	// In the Software Catalogue, deprecated dogus are marked with a warning sign.
 	//
 	Deprecated bool
 	// Namespace contains the dogu's namespace without the name.
@@ -59,6 +61,7 @@ type MarketingDogu struct {
 	//   - official
 	//   - premium
 	//
+	// See also Dogu.Name for how dogu names are constructed.
 	Namespace string
 	// Name contains the dogu's simple name without the namespace.
 	//
@@ -69,6 +72,7 @@ type MarketingDogu struct {
 	//   - confluence
 	//   - newdogu
 	//
+	// See also Dogu.Name for how dogu names are constructed.
 	Name string
 	// DisplayName is the name of the dogu which is used in UI frontends to represent the dogu.
 	//
@@ -78,17 +82,18 @@ type MarketingDogu struct {
 	//  - My New Dogu
 	//
 	DisplayName string
-	// Provider contains information about the provider of the dogu.
+	// A provider is an entity that provides / maintains / develops the dogu.
+	// The provider is a company in most cases.
 	//
 	// Example:
-	// 	{
-	//		"Slug": "provider",
-	//		"Name": "Provider",
+	// 	[{
+	//		"Slug": "cloudogu",
+	//		"Name": "Cloudogu GmbH",
 	//		"Logo": {
 	//			"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
-	//			"Title": "Provider Logo"
+	//			"Title": "Cloudogu GmbH logo"
 	//		}
-	//	}
+	//	}]
 	//
 	Provider []Provider
 	// Logo contains information about the logo or icon of the dogu.
@@ -128,16 +133,16 @@ type MarketingDogu struct {
 	ReleaseNotes string
 }
 
-// Provider describes properties of the provider of the dogu which can be used to represent the provider in UI frontends.
+// Provider describes properties of the dogu's publisher.  These properties can be used to represent the provider in UI frontends so administrators and users can faster find appropriate support.
 //
 // Example:
 //
 //	{
-//		"Slug": "provider",
-//		"Name": "Provider",
+//		"Slug": "cloudogu",
+//		"Name": "Cloudogu GmbH",
 //		"Logo": {
 //			"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
-//			"Title": "Provider Logo"
+//			"Title": "Cloudogu GmbH logo"
 //		}
 //	}
 type Provider struct {

--- a/core/marketing_dogu.go
+++ b/core/marketing_dogu.go
@@ -1,0 +1,222 @@
+package core
+
+// MarketingDogu describes properties of a dogu which can be used to enhance the representation of a dogu in UI frontends.
+//
+// Example:
+//
+//	{
+//		"ID": "0191b1e2-350f-7ecf-a0a8-6f2a2f0d3607",
+//		"Deprecated": false,
+//		"Namespace": "official",
+//		"Name": "newdogu",
+//		"DisplayName": "My New Dogu",
+//		"Provider": [
+//			{
+//				"Slug": "provider",
+//				"Name": "Provider",
+//				"Logo": {
+//					"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+//					"Title": "Provider logo"
+//				}
+//			}
+//		],
+//		"Logo": {
+//			"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+//			"Title": "Dogu icon"
+//		},
+//		"BackgroundImage": {
+//			"ID": "18a5dc18-c202-40b2-9ee0-7f917ad82406",
+//			"Title": "Screenshot of the main page of the new dogu"
+//		},
+//		"Descriptions": [
+//			{
+//				"Description": "Ein neues Dogu",
+//				"LanguageCode": "de"
+//			},
+//			{
+//				"Description": "A new dogu",
+//				"LanguageCode": "en"
+//			}
+//		],
+//		"ReleaseNotes": "https://example.com/release-notes"
+//	}
+type MarketingDogu struct {
+	// ID contains the unique identifier of the dogu given by the CMS.
+	//
+	// Examples:
+	//   - 0191b1e2-350f-7ecf-a0a8-6f2a2f0d3607
+	//   - 34393ef9-a96d-4d1d-823e-0c17b10b762d
+	//
+	ID string
+	// Deprecated indicates if the dogu is deprecated.
+	//
+	Deprecated bool
+	// Namespace contains the dogu's namespace without the name.
+	//
+	// Name together with Namespace delimited by a single forward slash "/" builds the dogu's full qualified name.
+	//
+	// Examples:
+	//   - official
+	//   - premium
+	//
+	Namespace string
+	// Name contains the dogu's simple name without the namespace.
+	//
+	// Name together with Namespace delimited by a single forward slash "/" builds the dogu's full qualified name.
+	//
+	// Examples:
+	//   - redmine
+	//   - confluence
+	//   - newdogu
+	//
+	Name string
+	// DisplayName is the name of the dogu which is used in UI frontends to represent the dogu.
+	//
+	// Examples:
+	//  - Jenkins CI
+	//  - Backup & Restore
+	//  - My New Dogu
+	//
+	DisplayName string
+	// Provider contains information about the provider of the dogu.
+	//
+	// Example:
+	// 	{
+	//		"Slug": "provider",
+	//		"Name": "Provider",
+	//		"Logo": {
+	//			"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+	//			"Title": "Provider Logo"
+	//		}
+	//	}
+	//
+	Provider []Provider
+	// Logo contains information about the logo or icon of the dogu.
+	//
+	// Example:
+	// 	{
+	//		"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+	//		"Title": "Dogu Logo"
+	//	}
+	//
+	Logo Image
+	// BackgroundImage contains information about the background image of the dogu.
+	//
+	// Example:
+	//	{
+	//		"ID": "18a5dc18-c202-40b2-9ee0-7f917ad82406",
+	//		"Title": "Screenshot of the main page of the new dogu"
+	//	}
+	//
+	BackgroundImage Image
+	// Descriptions contains a short explanation, what the dogu does in different languages.
+	//
+	// Example:
+	// 	{
+	//		"Description": "Ein neues Dogu",
+	//		"LanguageCode": "de"
+	//	},
+	//	{
+	//		"Description": "A new dogu",
+	//		"LanguageCode": "en"
+	//	}
+	Descriptions []Translations
+	// ReleaseNotes contains an URL to the release notes of the dogu.
+	//
+	// Example:
+	//	- https://example.com/release-notes
+	ReleaseNotes string
+}
+
+// Provider describes properties of the provider of the dogu which can be used to represent the provider in UI frontends.
+//
+// Example:
+//
+//	{
+//		"Slug": "provider",
+//		"Name": "Provider",
+//		"Logo": {
+//			"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+//			"Title": "Provider Logo"
+//		}
+//	}
+type Provider struct {
+	// Slug contains the URL-ID of the provider which is part of an URL to access the providers page.
+	//
+	// Examples:
+	//   - cloudogu
+	//   - my-provider
+	//
+	Slug string
+	// Name contains the name of the provider.
+	//
+	// Examples:
+	//   - Cloudogu GmbH
+	//   - Easy Software Ltd.
+	//
+	Name string
+	// Logo contains information about the logo  of the provider.
+	//
+	// Example:
+	// 	{
+	//		"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+	//		"Title": "Provider Logo"
+	//	}
+	//
+	Logo Image
+}
+
+// Image describes properties of an image which can be used to represent the image in UI frontends.
+//
+// Example:
+//
+//	{
+//		"ID": "34393ef9-a96d-4d1d-823e-0c17b10b762d",
+//		"Title": "Screenshot of the main page of the new dogu"
+//	}
+type Image struct {
+	// ID contains the unique identifier of the image given by the CMS. The ID can be used to fetch the image from CMS.
+	//
+	// Examples:
+	//   - 34393ef9-a96d-4d1d-823e-0c17b10b762d
+	//	 - 18a5dc18-c202-40b2-9ee0-7f917ad82406
+	//
+	ID string
+	// Title contains the title of the image which is used for accessibility reasons.
+	//
+	// Examples:
+	//   - Screenshot of the main page of the new dogu
+	//   - Logo of the provider
+	//
+	Title string
+}
+
+// Translations describes properties of a description of a dogu in a specific language. It can be used to represent the dogu's description in UI frontends
+// in different languages.
+//
+// Example:
+//
+//	{
+//		"Description": "MySQL - Relationale Datenbank",
+//		"LanguageCode": "de"
+//	},
+//	{
+//		"Description": "MySQL - Relational database",
+//		"LanguageCode": "en"
+//	}
+type Translations struct {
+	// Description contains a short explanation, what the dogu does in a specific language.
+	//
+	// Examples:
+	//  - MySQL - Relationale Datenbank
+	//  - Jenkins Continuous Integration Server
+	//
+	Description string
+	// LanguageCode contains the ISO-639-1 code of the language in which the description is written.
+	//
+	// Examples:
+	//   - de
+	//   - en
+	//
+	LanguageCode string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "2"
 services:
   etcd:
-    image: quay.io/coreos/etcd:v3.2.5
-    command: ["etcd","--listen-client-urls", "http://0.0.0.0:4001", "--advertise-client-urls", "http://0.0.0.0:4001"]
+    image: quay.io/coreos/etcd:v3.2.32
+    command: ["etcd", "--listen-client-urls", "http://0.0.0.0:4001", "--advertise-client-urls", "http://0.0.0.0:4001"]
     ports:
       - "4001:4001"
       - "2379:2379"


### PR DESCRIPTION
Adds a marketing dogu struct which will be used in to represent additional information to a dogu in the new marketing endpoint of dog.cloudogu.com.