### PR TITLE
Fix doc comment on Dogu.Encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixes a typo regarding which key will be used for encryption
 
 ## [v0.12.2] - 2023-10-24
 ### Changed

--- a/core/dogu_v2.go
+++ b/core/dogu_v2.go
@@ -348,7 +348,7 @@ type ConfigurationField struct {
 	//
 	Optional bool
 	// Encrypted marks this configuration field to contain a sensitive value that will be encrypted with the dogu's
-	// private key. This field is optional. If unset, a value of `false` will be assumed.
+	// public key. This field is optional. If unset, a value of `false` will be assumed.
 	//
 	// Example:
 	//   - true


### PR DESCRIPTION
Public-Key encryption works this way that a value will be encrypted with the public key but can only be decrypted with the private key. This doc comment got it the wrong way around

This part was prematurely translated in cloudogu/dogu-development-docs.