### PR TITLE
#50 Allow Version to be used as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#50] Add string representation to `core.Version`
 
 ## [v0.14.4] - 2024-11-06
 ### Fixed

--- a/core/version.go
+++ b/core/version.go
@@ -65,7 +65,7 @@ func ParseVersion(raw string) (Version, error) {
 }
 
 // Version struct can be used to extract single parts of a version number or to compare version with each other.
-// The version struct can with four or less digits, plus an extra version which is divided by a hyphen.
+// The version struct can with four or fewer digits, plus an extra version which is divided by a hyphen.
 // For example: 4.0.7.11-3 => 4 Major, 0 Minor, 7 Patch, 11 Nano, 3 Extra
 type Version struct {
 	Raw   string
@@ -140,6 +140,31 @@ func (v *Version) compare(o Version) comparisonResult {
 
 func (v *Version) getParts() []int {
 	return []int{v.Major, v.Minor, v.Patch, v.Nano, v.Extra}
+}
+
+// String returns a string representation of a Version object. The string will be reduced to the format Major.Minor.Patch
+// if the values of Extra and/or Nano are equal to zero and thus indicating that they are not set.
+func (v *Version) String() string {
+	if v.Raw != "" {
+		return v.Raw
+	}
+
+	verBuilder := strings.Builder{}
+	verBuilder.WriteString(strconv.Itoa(v.Major))
+	verBuilder.WriteString(".")
+	verBuilder.WriteString(strconv.Itoa(v.Minor))
+	verBuilder.WriteString(".")
+	verBuilder.WriteString(strconv.Itoa(v.Patch))
+	if v.Nano != 0 || v.Extra != 0 {
+		verBuilder.WriteString(".")
+		verBuilder.WriteString(strconv.Itoa(v.Nano))
+	}
+	if v.Extra != 0 {
+		verBuilder.WriteString("-")
+		verBuilder.WriteString(strconv.Itoa(v.Extra))
+	}
+
+	return verBuilder.String()
 }
 
 // ByVersion implements sort.Interface for []Version to sort versions

--- a/core/version_test.go
+++ b/core/version_test.go
@@ -282,3 +282,40 @@ func assertNegativeIsNewerOrEqualThan(t *testing.T, s1, s2 string) {
 	version2, _ := ParseVersion(s2)
 	assert.False(t, version1.IsNewerOrEqualThan(version2), "version %s should not be newer or equal than %s", s1, s2)
 }
+
+func TestVersion_String(t *testing.T) {
+	type fields struct {
+		Raw   string
+		Major int
+		Minor int
+		Patch int
+		Nano  int
+		Extra int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{"return raw", fields{Raw: "1.2.3.4-5"}, "1.2.3.4-5"},
+		{"return 1-part version", fields{Major: 1}, "1.0.0"},
+		{"return 2-part version", fields{Major: 1, Minor: 2}, "1.2.0"},
+		{"return 3-part version", fields{Major: 1, Minor: 2, Patch: 3}, "1.2.3"},
+		{"return 4-part version", fields{Major: 1, Minor: 2, Patch: 3, Nano: 4}, "1.2.3.4"},
+		{"return 5-part version", fields{Major: 1, Minor: 2, Patch: 3, Nano: 4, Extra: 5}, "1.2.3.4-5"},
+		{"return version for empty", fields{}, "0.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Version{
+				Raw:   tt.fields.Raw,
+				Major: tt.fields.Major,
+				Minor: tt.fields.Minor,
+				Patch: tt.fields.Patch,
+				Nano:  tt.fields.Nano,
+				Extra: tt.fields.Extra,
+			}
+			assert.Equalf(t, tt.want, v.String(), "String()")
+		})
+	}
+}


### PR DESCRIPTION
This PR resolves #50 by adding making `core.Version` implement the `Stringer` interface so anyone with a Version object can easily print a string representation which is not as ugly as the following printf output:
`{7.4.3 %!s(int=7) %!s(int=4) %!s(int=3) %!s(int=0) %!s(int=0)}`