### PR TITLE
Fix example ExposedPort doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed examples doc comments for `ExposedPort`
 
 ## [v0.18.1] - 2025-02-28
 ### Changed

--- a/core/dogu_v2.go
+++ b/core/dogu_v2.go
@@ -75,8 +75,8 @@ type HealthCheck struct {
 //
 // Example:
 //
-//	{ "Type": "tcp", "Container": "2222", "Host":"2222" }
-//	{ "Container": "2222", "Host":"2222" }
+//	{ "Type": "tcp", "Container": 2222, "Host": 2222 }
+//	{ "Container": 2222, "Host": 2222 }
 type ExposedPort struct {
 	// Type contains the protocol type over which the container communicates (f. i. 'tcp'). This field is optional (the
 	// value of `tcp` is then assumed).
@@ -418,7 +418,7 @@ type Dogu struct {
 	//
 	// Examples:
 	//
-	//   [ { "Type": "tcp", "Container": "2222", "Host":"2222" } ]
+	//   [ { "Type": "tcp", "Container": 2222, "Host": 2222 } ]
 	//
 	ExposedPorts []ExposedPort
 	// ExposedCommands defines actions of type [ExposedCommand] which can be executed in different phases of


### PR DESCRIPTION
The data structure just takes integer values not strings. The example is thus misleading.